### PR TITLE
PEP8 Compliance Changes for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,32 @@
 '''
 DISTRIBUTION STATEMENT A. Approved for public release: distribution unlimited.
 
-This material is based upon work supported by the Assistant Secretary of Defense for 
-Research and Engineering under Air Force Contract No. FA8721-05-C-0002 and/or 
+This material is based upon work supported by the Assistant Secretary of Defense for
+Research and Engineering under Air Force Contract No. FA8721-05-C-0002 and/or
 FA8702-15-D-0001. Any opinions, findings, conclusions or recommendations expressed in this
-material are those of the author(s) and do not necessarily reflect the views of the 
+material are those of the author(s) and do not necessarily reflect the views of the
 Assistant Secretary of Defense for Research and Engineering.
 
 Copyright 2015 Massachusetts Institute of Technology.
 
 The software/firmware is provided to you on an As-Is basis
 
-Delivered to the US Government with Unlimited Rights, as defined in DFARS Part 
-252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S. Government 
-rights in this work are defined by DFARS 252.227-7013 or DFARS 252.227-7014 as detailed 
-above. Use of this work other than as specifically authorized by the U.S. Government may 
+Delivered to the US Government with Unlimited Rights, as defined in DFARS Part
+252.227-7013 or 7014 (Feb 2014). Notwithstanding any copyright notice, U.S. Government
+rights in this work are defined by DFARS 252.227-7013 or DFARS 252.227-7014 as detailed
+above. Use of this work other than as specifically authorized by the U.S. Government may
 violate any copyrights that exist in this work.
 '''
 
+# pylint: disable-msg=C0103,W0622
 
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages, Extension
 # To use a consistent encoding
 from codecs import open
 from os import path
 from os import walk
 import sys
+# Always prefer setuptools over distutils
+from setuptools import setup, Extension
 
 here = path.abspath(path.dirname(__file__))
 
@@ -35,20 +36,19 @@ with open(path.join(here, 'DESCRIPTION.md'), encoding='utf-8') as f:
 
 # cLime only builds against glibc at the moment. If we ever want to change this
 # it shouldn't be too hard.
-extensions = []    
+extensions = []
 if 'linux' in sys.platform:
     extensions.append(Extension('_cLime',
-                            define_macros = [('MAJOR_VERSION', '1'),
-                                             ('MINOR_VERSION', '0')],
-                            include_dirs = ['/usr/local/include'],
-                            libraries = ['tpm', 'keylime'],
-                            library_dirs = ['/usr/local/lib'],
-                            runtime_library_dirs = ['/usr/local/lib'],
-                            sources = ['keylime/_cLime.c']))
+                                define_macros=[('MAJOR_VERSION', '1'), ('MINOR_VERSION', '0')],
+                                include_dirs=['/usr/local/include'],
+                                libraries=['tpm', 'keylime'],
+                                library_dirs=['/usr/local/lib'],
+                                runtime_library_dirs=['/usr/local/lib'],
+                                sources=['keylime/_cLime.c']))
 
 
-# enumerate all of the data files we need to package up 
-data_files = [(d, [path.join(d,f) for f in files]) for d,_,files in walk("keylime/static")]
+# enumerate all of the data files we need to package up
+data_files = [(d, [path.join(d, f) for f in files]) for d, _, files in walk("keylime/static")]
 data_files.append(('package_default', ['keylime.conf']))
 
 setup(
@@ -83,12 +83,12 @@ setup(
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
-        
+
         # where does it run
         'Environment :: Console',
         'Operating System :: POSIX',
         'Operating System :: POSIX :: Linux',
-        
+
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: BSD License',
 
@@ -109,10 +109,10 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pycryptodomex>=3.4.1','tornado>=4.3','m2crypto>=0.21.1','pyzmq>=14.4'],
-    
+    install_requires=['pycryptodomex>=3.4.1', 'tornado>=4.3', 'm2crypto>=0.21.1', 'pyzmq>=14.4'],
+
     # test packages required
-    tests_require=['green','coverage'],   
+    tests_require=['green', 'coverage'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -152,5 +152,5 @@ setup(
         ],
     },
 
-    ext_modules = extensions
+    ext_modules=extensions
 )


### PR DESCRIPTION
Changes made to `setup.py` to allow for PEP8 Compliance as per issue #10

Removed `find_packages` as not used.

Added two pylint ignores for false postives on constant naming case and Redefining built-in 'open'. 