### PR TITLE
Adds a contributors guide [ci skip]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,104 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish
+to make via an [issue](https://github.com/keylime/python-keylime/issues) or email to the [keylime mailing list](https://groups.io/g/keylime).
+
+## Pull Request Process
+
+1. Create an [issue](https://github.com/keylime/python-keylime/issues)
+   outlining the fix or feature.
+2. Fork the keylime repository to your own github account and clone it locally.
+3. Hack on your changes.
+4. Update the README.md or documentation with details of changes to any
+   interface, this includes new environment variables, exposed ports, useful
+   file locations, CLI parameters and configuration values.
+5. Add and commit your changes with some descriptive text on the nature of the
+   change / feature in your commit message. Also reference the issue raised at
+   [1] as follows: `Fixes #45`. See [here](https://help.github.com/articles/closing-issues-using-keywords/)
+   for more message types
+6. Ensure that CI passes, if it fails, fix the failures.
+7. Every pull request requires a review from the [core keylime team](https://github.com/orgs/keylime/teams/core)
+   before merging.
+
+## Developers environment
+
+[pending]
+
+## Run CI tests locally
+
+[pending]
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <core@keylime.groups.io>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This provides information for new contributors, including PR
workflow and code of conduct.

Some placeholders exist for futher pages on setting up a developers
environment and running CI tests locally.