### PR TITLE
Don't pass -I option to bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The brief synopsis of a quick build/install (after installing dependencies) is:
 ```bash
 git clone https://github.com/tpm2-software/tpm2-tss.git tpm2-tss
 pushd tpm2-tss
-./bootstrap -I /usr/share/gnulib/m4
+./bootstrap
 ./configure --prefix=/usr
 make
 sudo make install

--- a/docker/Dockerfile-tpm20
+++ b/docker/Dockerfile-tpm20
@@ -74,7 +74,7 @@ ENV init /lib/systemd/systemd
 
 RUN git clone https://github.com/tpm2-software/tpm2-tss.git ${TPM2_TSS}
 WORKDIR ${TPM2_TSS}
-RUN ./bootstrap -I /usr/share/gnulib/m4
+RUN ./bootstrap
 RUN ./configure --prefix=/usr --disable-doxygen-doc
 RUN make
 RUN make install

--- a/installer.sh
+++ b/installer.sh
@@ -385,7 +385,7 @@ elif [[ "$TPM_VERSION" -eq "2" ]] ; then
     git clone $TPM2TSS_GIT tpm2-tss
     pushd tpm2-tss
     git checkout $TPM2TSS_VER
-    ./bootstrap -I /usr/share/gnulib/m4
+    ./bootstrap
     ./configure --prefix=/usr
     make
     make install


### PR DESCRIPTION
Recent version of tss doesn't need -I param to
be passed to bootstrap.