### PR TITLE
Update demo_setup.sh and create_whitelist.sh for Debian systems

### DIFF
--- a/demo/demo_setup.sh
+++ b/demo/demo_setup.sh
@@ -172,7 +172,7 @@ esac
 
 echo 
 echo "=================================================================================="
-echo $'\t\t\t\tUpdating $NAME packages'
+echo $'\t\t\t\tUpdating packages'
 echo "=================================================================================="
 ${PACKAGE_MANAGER} update -y 
 
@@ -284,17 +284,5 @@ if [[ "$IMA_ENABLE" -eq "1" ]] ; then
     echo $'\t\t\t\tGenerating IMA whitelist'
     echo "=================================================================================="
     cd $KEYLIME_DIR/keylime/
-    case "$ID" in
-    debian | ubuntu)
-        initdisk="initrd"
-    ;;
-
-    redhat | centos | fedora)
-        initdisk="initramfs"
-    ;;
-    *)
-        echo "${ID} is not currently supported."
-        exit 1
-    esac
-    ./create_whitelist.sh whitelist.sh ${initdisk}
+    ./create_whitelist.sh whitelist.txt
 fi

--- a/keylime/create_whitelist.sh
+++ b/keylime/create_whitelist.sh
@@ -21,6 +21,29 @@
 #
 ##########################################################################################
 
+# Configure the installer here
+INITRAMFS_TOOLS_GIT=https://salsa.debian.org/kernel-team/initramfs-tools.git
+INITRAMFS_TOOLS_VER="master"
+
+
+# Grabs Debian's initramfs_tools from Git repo if no other options exist
+if [[ ! `command -v unmkinitramfs` && ! -x "/usr/lib/dracut/skipcpio" ]] ; then
+    # Create temp dir for pulling in initramfs-tools
+    TMPDIR=`mktemp -d` || exit 1
+    echo "INFO: Downloading initramfs-tools: $TMPDIR"
+
+    # Clone initramfs-tools repo
+    pushd $TMPDIR
+    git clone $INITRAMFS_TOOLS_GIT initramfs-tools
+    pushd initramfs-tools
+    git checkout $INITRAMFS_TOOLS_VER
+    popd # $TMPDIR
+    popd
+
+    shopt -s expand_aliases
+    alias unmkinitramfs=$TMPDIR/initramfs-tools/unmkinitramfs
+fi
+
 
 if [[ $EUID -ne 0 ]]; then
     echo "This script must be run as root" 1>&2
@@ -46,12 +69,15 @@ rm -f $OUTPUT
 
 echo "Writing whitelist to $OUTPUT with $ALGO..."
 
+# Add all appropriate files under root FS to whitelist
 cd /
 find `ls / | grep -v "\bsys\b\|\brun\b\|\bproc\b\|\blost+found\b\|\bdev\b\|\bmedia\b\|\bsnap\b\|mnt"` \( -fstype rootfs -o -xtype f -type l -o -type f \) -uid 0 -exec $ALGO '/{}' >> $OUTPUT \;
 
+# Create staging area for init ram images
 rm -rf /tmp/ima/
 mkdir -p /tmp/ima
 
+# Iterate through init ram disks and add files to whitelist
 echo "Creating whitelist for init ram disk"
 for i in `ls /boot/initr*`
 do
@@ -63,14 +89,20 @@ do
     if [[ `command -v unmkinitramfs` ]] ; then
         mkdir -p /tmp/ima/$i-extracted-unmk
         unmkinitramfs $i /tmp/ima/$i-extracted-unmk
-        cp -r /tmp/ima/$i-extracted-unmk/main/. /tmp/ima/$i-extracted
+        if [[ -d "/tmp/ima/$i-extracted-unmk/main/" ]] ; then
+            cp -r /tmp/ima/$i-extracted-unmk/main/. /tmp/ima/$i-extracted
+        else
+            cp -r /tmp/ima/$i-extracted-unmk/. /tmp/ima/$i-extracted
+        fi
     elif [[ -x "/usr/lib/dracut/skipcpio" ]] ; then
         /usr/lib/dracut/skipcpio $i | gunzip -c | cpio -i -d 2> /dev/null
     else
-        gzip -dc $i | cpio -id 2> /dev/null
+        echo "ERROR: No tools for initramfs image processing found!"
+        break
     fi
 
     find -type f -exec sha1sum "./{}" \; | sed "s| \./\./| /|" >> $OUTPUT
 done
-rm -rf /tmp/ima
 
+# Clean up
+rm -rf /tmp/ima


### PR DESCRIPTION
Noticed that there are some issues grabbing the initrd files in modern Debian-based systems using the traditional `gzip`-`cpio` method.  Newer Debian-based systems now provide `unmkinitramfs` to unpack initramfs images, which we can leverage.  In the worst case, fall back to using `gzip`-`cpio`. 

This method also allows `create_whitelist.sh` to be more flexible with parsing init ram images (no need to pass in "initrd" or "initrams" on the command line. 