### PR TITLE
Writing to NVRAM failures should not be an (uncaught) exception

### DIFF
--- a/keylime/tpm1.py
+++ b/keylime/tpm1.py
@@ -839,8 +839,8 @@ class tpm1(AbstractTPM):
             keyFile.write(key)
             keyFile.flush()
             
-            self.__run("nv_definespace -pwdo %s -in 1 -sz %d -pwdd %s -per 40004"%(owner_pw,common.BOOTSTRAP_KEY_SIZE,owner_pw))
-            self.__run("nv_writevalue -pwdd %s -in 1 -if %s"%(owner_pw,keyFile.name))
+            self.__run("nv_definespace -pwdo %s -in 1 -sz %d -pwdd %s -per 40004"%(owner_pw,common.BOOTSTRAP_KEY_SIZE,owner_pw),raiseOnError=False)
+            self.__run("nv_writevalue -pwdd %s -in 1 -if %s"%(owner_pw,keyFile.name),raiseOnError=False)
         return
 
     def read_ekcert_nvram(self):

--- a/keylime/tpm2.py
+++ b/keylime/tpm2.py
@@ -897,8 +897,8 @@ class tpm2(AbstractTPM):
             keyFile.flush()
             
             attrs = "ownerread|policywrite|ownerwrite"
-            self.__run("tpm2_nvdefine -x 0x1500018 -a 0x40000001 -s %s -t \"%s\" -p %s -P %s"%(common.BOOTSTRAP_KEY_SIZE, attrs, owner_pw, owner_pw))
-            self.__run("tpm2_nvwrite -x 0x1500018 -a 0x40000001 -P %s %s"%(owner_pw, keyFile.name))
+            self.__run("tpm2_nvdefine -x 0x1500018 -a 0x40000001 -s %s -t \"%s\" -p %s -P %s"%(common.BOOTSTRAP_KEY_SIZE, attrs, owner_pw, owner_pw), raiseOnError=False)
+            self.__run("tpm2_nvwrite -x 0x1500018 -a 0x40000001 -P %s %s"%(owner_pw, keyFile.name), raiseOnError=False)
         return
 
     def read_ekcert_nvram(self):


### PR DESCRIPTION
This breaks functionality in loading payloads into a node, see [keylime/cloud_node.py#L231](https://github.com/keylime/python-keylime/blob/master/keylime/cloud_node.py#L231).  

This will cause an exit out of the provisioning process and prevent any payloads from being loaded in. 

Also, we handle reading from NVRAM failures in the same way. 